### PR TITLE
Add 4-gate enforcement + PRD audit-in-implement

### DIFF
--- a/.claude/agents/prd-auditor.md
+++ b/.claude/agents/prd-auditor.md
@@ -1,28 +1,65 @@
 ---
 name: "prd-auditor"
-description: "Audits implementation compliance against PRD and feature specs"
+description: "Audits implementation compliance against PRD and feature specs. Fixes gaps or documents blockers."
 model: sonnet
 ---
 
-You are a PRD compliance auditor. Your job is to verify that the implementation matches the Product Requirements Document and feature specifications.
+You are a PRD compliance auditor. You verify that the implementation matches the Product Requirements Document and feature specifications. You attempt to fix gaps. If a gap cannot be fixed, you document it as a blocker and ask for user confirmation.
 
-## How to audit
+## Audit Process
 
 1. Read `docs/PRD.md` for product requirements
 2. Read `.specify/memory/constitution.md` for governing principles
-3. Find all specs in `specs/*/spec.md`
-4. Read the actual source code to verify compliance
-5. Produce a structured PASS/PARTIAL/FAIL report
+3. Find all specs in `specs/*/spec.md` — extract every FR-NNN
+4. Find all tasks in `specs/*/tasks.md` — verify all marked `[x]`
 
-## What to check
+## What to Check
 
-- Every PRD functional requirement has a spec FR covering it
-- Every spec FR is implemented in code (look for `// FR-NNN` comments)
-- Every acceptance scenario has a test (look for scenario references in test comments)
-- Tech stack matches PRD
-- No scope creep (nothing built that wasn't specified)
-- No gaps (nothing specified that wasn't built)
+For each FR-NNN in the spec:
 
-## Output format
+| Check | Method |
+|-------|--------|
+| PRD → Spec | Does the spec FR trace to a PRD requirement? |
+| Spec → Code | Search source files for `// FR-NNN` comment |
+| Code → Test | Search test files for acceptance scenario references |
+| Tech stack | Compare PRD required stack vs actual dependencies |
+| Scope creep | Anything implemented that wasn't specified |
 
-Use tables with PASS/PARTIAL/FAIL status. List critical gaps first, then partial, then recommendations.
+## Fix-or-Block Flow
+
+For each failing check:
+
+**Try to fix it:**
+- Missing FR comment → add to the correct function
+- Missing test reference → add scenario comment to test
+- Missing test → write the test
+- Missing implementation → implement the FR
+
+**If unfixable, create a blocker:**
+Append to `specs/<feature>/blockers.md`:
+```markdown
+## Blocker: FR-NNN — [description]
+**Status**: BLOCKED
+**Reason**: [why this cannot be fixed]
+**Impact**: [user-facing effect]
+**Resolution path**: [what would need to change]
+**Date**: [today]
+```
+
+## Output
+
+```
+PRD Compliance: XX% (Y/Z requirements)
+- PASS: N fully implemented and tested
+- FIXED: N gaps resolved during audit
+- BLOCKED: N with documented blockers (requires user confirmation)
+```
+
+If blockers exist, STOP and ask user to confirm before proceeding.
+
+## Rules
+
+- Read actual source code, not just filenames
+- Quote file:line for every gap
+- Every gap must be FIXED or BLOCKED — never silently skipped
+- User MUST confirm blockers before audit can pass

--- a/.claude/hooks/require-spec.sh
+++ b/.claude/hooks/require-spec.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Block Edit/Write on src/ files unless the full speckit workflow is complete:
-# 1. spec.md exists
-# 2. plan.md exists
-# 3. tasks.md exists
+# Gate 1: spec.md exists
+# Gate 2: plan.md exists
+# Gate 3: tasks.md exists
+# Gate 4: tasks.md has at least one [X] mark (proves /speckit.implement ran)
 # Allows edits to docs, specs, config, scripts, tests, and non-src files always.
 
 set -euo pipefail
@@ -24,7 +25,7 @@ fi
 # Always allow edits to non-src files
 case "$FILE_PATH" in
   */docs/*|*/specs/*|*/scripts/*|*/.claude/*|*/.specify/*|*/tests/*|\
-  *CLAUDE.md|*README.md|*.json|*.yml|*.yaml|*.toml|*.md|*.gitignore|\
+  *CLAUDE.md|*README.md|*.yml|*.yaml|*.toml|*.gitignore|\
   */.env*|*/node_modules/*)
     exit 0
     ;;
@@ -33,19 +34,27 @@ esac
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
 MISSING=""
 
-# Check 1: spec.md exists
+# Gate 1: spec.md exists
 if ! ls "$PROJECT_DIR"/specs/*/spec.md >/dev/null 2>&1; then
   MISSING="$MISSING\n  - spec.md (run /speckit.specify)"
 fi
 
-# Check 2: plan.md exists
+# Gate 2: plan.md exists
 if ! ls "$PROJECT_DIR"/specs/*/plan.md >/dev/null 2>&1; then
   MISSING="$MISSING\n  - plan.md (run /speckit.plan)"
 fi
 
-# Check 3: tasks.md exists
+# Gate 3: tasks.md exists
 if ! ls "$PROJECT_DIR"/specs/*/tasks.md >/dev/null 2>&1; then
   MISSING="$MISSING\n  - tasks.md (run /speckit.tasks)"
+fi
+
+# Gate 4: tasks.md has at least one checked task [X] (proves /speckit.implement ran)
+if ls "$PROJECT_DIR"/specs/*/tasks.md >/dev/null 2>&1; then
+  TASKS_FILE=$(ls "$PROJECT_DIR"/specs/*/tasks.md 2>/dev/null | head -1)
+  if ! grep -q '\[[xX]\]' "$TASKS_FILE" 2>/dev/null; then
+    MISSING="$MISSING\n  - No tasks marked complete (run /speckit.implement)"
+  fi
 fi
 
 # If nothing missing, allow
@@ -53,17 +62,15 @@ if [[ -z "$MISSING" ]]; then
   exit 0
 fi
 
-# Block with specific guidance on what's missing
+# Block with specific guidance
 cat >&2 <<EOF
-BLOCKED: Speckit workflow incomplete. Missing artifacts:
+BLOCKED: Speckit workflow incomplete. Missing:
 $(echo -e "$MISSING")
 
-The full workflow before writing code:
-1. /speckit.specify  → creates spec.md
-2. /speckit.plan     → creates plan.md
-3. /speckit.tasks    → creates tasks.md
-4. Then implement
-
-Each artifact must exist in specs/<feature>/ before editing src/ files.
+Required workflow before editing source files:
+1. /speckit.specify   → creates spec.md
+2. /speckit.plan      → creates plan.md
+3. /speckit.tasks     → creates tasks.md
+4. /speckit.implement → executes tasks, marks [X], runs PRD audit
 EOF
 exit 2

--- a/.claude/skills/speckit-audit/SKILL.md
+++ b/.claude/skills/speckit-audit/SKILL.md
@@ -1,42 +1,105 @@
 ---
 name: "speckit-audit"
-description: "Run a PRD compliance audit against the current implementation"
+description: "Run a PRD compliance audit against the current implementation. Called automatically at the end of /speckit.implement. Attempts to fix gaps, or requires documented blockers before proceeding."
 ---
 
 ## PRD Compliance Audit
 
-Audit the current implementation against the PRD and feature specs.
+This audit runs as the final step of `/speckit.implement`. It verifies the implementation matches the PRD and spec, attempts to fix any gaps, and provides an escape hatch for legitimate blockers.
 
-### Workflow
+### Phase 1: Gather Context
 
-1. Read `docs/PRD.md` to understand the product requirements.
+1. Read `docs/PRD.md` for product requirements.
 2. Read `.specify/memory/constitution.md` for governing principles.
-3. Find all specs in `specs/*/spec.md`.
-4. For each PRD functional requirement:
-   - Check if a spec FR covers it
-   - Check if implementation satisfies the spec FR
-   - Grade as PASS / PARTIAL / FAIL
-5. For each spec FR:
-   - Check if a function references it
-   - Check if a test validates its acceptance scenario
-   - Grade as PASS / PARTIAL / FAIL
-6. Check tech stack compliance (PRD vs actual).
-7. Check success metrics achievability.
-8. Identify gaps: PRD → spec, spec → implementation, implementation → tests.
+3. Find all specs in `specs/*/spec.md` — extract all FR-NNN requirements.
+4. Find all tasks in `specs/*/tasks.md` — verify all are marked `[x]`.
 
-### Output
+### Phase 2: Audit
 
-Produce a structured report with:
-- Overall compliance percentage
-- Per-requirement PASS/PARTIAL/FAIL table
-- Critical gaps (must fix)
-- Partial gaps (should fix)
-- Recommendations prioritized by severity
-- Scope creep check (anything built that wasn't specified)
+For each PRD functional requirement:
+
+| Check | How | Grade |
+|-------|-----|-------|
+| PRD → Spec coverage | Does a spec FR cover this PRD requirement? | PASS / FAIL |
+| Spec → Code coverage | Does source code contain `// FR-NNN` referencing this FR? | PASS / FAIL |
+| Code → Test coverage | Does a test reference the acceptance scenario? | PASS / FAIL |
+| Tech stack | Does the implementation use the PRD's required tech stack? | PASS / FAIL |
+| Scope creep | Is anything built that wasn't in the spec? | PASS / WARN |
+
+Produce a summary table:
+```
+| FR | PRD→Spec | Spec→Code | Code→Test | Status |
+|----|----------|-----------|-----------|--------|
+| FR-001 | PASS | PASS | PASS | ✓ |
+| FR-002 | PASS | FAIL | — | ✗ |
+```
+
+Calculate overall compliance: `(passing checks / total checks) * 100`
+
+### Phase 3: Fix or Block
+
+**If compliance >= 100%**: Report PASS. Implementation is complete.
+
+**If compliance < 100%**: For each failing check:
+
+1. **Attempt to fix** — if the gap is:
+   - Missing `// FR-NNN` comment → add it to the correct function
+   - Missing test scenario reference → add the comment to the test
+   - Missing test for an acceptance scenario → write the test
+   - Missing implementation for a spec FR → implement it
+   - Report what was fixed and re-run that check
+
+2. **If the gap cannot be fixed** — because:
+   - The PRD requirement contradicts another requirement
+   - A dependency is unavailable (API, service, hardware)
+   - The requirement is out of scope for the current phase
+   - The tech stack constraint makes it impossible
+
+   Then **require a blocker entry**:
+
+   Create or append to `specs/<feature>/blockers.md`:
+   ```markdown
+   ## Blocker: FR-NNN — [requirement description]
+
+   **Status**: BLOCKED
+   **Reason**: [specific reason this cannot be fixed]
+   **Impact**: [what user-facing functionality is affected]
+   **Resolution path**: [what would need to change — PRD update, dependency available, etc.]
+   **Date**: [ISO date]
+   ```
+
+3. **After all gaps are addressed** (fixed or blocked):
+   - Re-run the audit on fixed items
+   - If any blockers were written, **STOP and ask the user**:
+     ```
+     PRD Audit: X of Y requirements pass. Z blockers documented.
+
+     Blockers:
+     - FR-NNN: [reason]
+     - FR-NNN: [reason]
+
+     These are documented in specs/<feature>/blockers.md.
+     Do you want to proceed with these known gaps? (yes/no)
+     ```
+   - Wait for user confirmation before continuing
+   - If user says no → halt, leave blockers.md for review
+   - If user says yes → proceed, implementation is accepted with documented gaps
+
+### Phase 4: Report
+
+Final output:
+```
+PRD Compliance: XX% (Y/Z requirements)
+- PASS: N requirements fully implemented and tested
+- FIXED: N gaps resolved during audit
+- BLOCKED: N requirements with documented blockers
+- FAIL: N requirements still failing (should be 0)
+```
 
 ### Rules
 
-- Be thorough — read actual source files, not just filenames
-- Quote specific line numbers when citing gaps
-- Distinguish between "not implemented" and "implemented differently than specified"
-- Flag any PRD requirements that the spec intentionally diverges from
+- Read actual source files, not just filenames
+- Quote specific file:line when citing gaps
+- Distinguish "not implemented" from "implemented differently than specified"
+- Never silently skip a failing requirement — every gap must be fixed or blocked
+- The user MUST confirm if any blockers exist before the audit passes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,24 +19,38 @@ Create `specs/<feature>/tasks.md` with ordered, dependency-aware task breakdown.
 ### 5. Commit All Artifacts Before Code
 spec.md, plan.md, and tasks.md MUST exist before any `src/` edits. Hooks enforce this.
 
-### 6. Implement with Traceability (/speckit.implement)
+### 6. Implement via /speckit.implement ONLY
+**Do NOT write implementation code directly.** Run `/speckit.implement` which:
+- Reads tasks.md and executes tasks phase-by-phase
+- Marks each completed task as `[X]` in tasks.md
+- Hooks verify tasks are being checked off — raw edits to src/ are BLOCKED until at least one task is marked `[X]`
 - Every function MUST reference its spec FR in a comment
 - Every test MUST reference the acceptance scenario it validates
+- **After all tasks complete, runs PRD audit automatically** (see step 7)
 
-### 5. Test with Coverage Gate
+### 7. PRD Audit (runs inside /speckit.implement)
+After implementation completes, `/speckit.implement` runs `/speckit.audit` which:
+- Checks every PRD requirement has a spec FR, implementation, and test
+- **Attempts to fix** gaps (missing comments, missing tests, missing implementation)
+- **If a gap cannot be fixed**: documents the reason in `specs/<feature>/blockers.md`
+- **If blockers exist**: STOPS and asks for user confirmation before proceeding
+- Reports overall compliance percentage
+
+### 8. Test with Coverage Gate
 - Run tests after every code change
 - New/changed code MUST achieve >=80% test coverage
 - Run `npm test` or `vitest run` to verify
 
-### 6. Verify Before Done
+### 9. Verify Before Done
 - Tests pass
 - Build succeeds
 - Coverage >=80%
+- PRD audit passed (or blockers acknowledged)
 - No lint errors
 
 ## File Organization
 
-- `src/` — source code (BLOCKED by hooks without a spec)
+- `src/` — source code (BLOCKED by hooks without spec + implement)
 - `tests/` — test files
 - `specs/` — feature specifications
 - `docs/` — documentation and PRD
@@ -44,30 +58,31 @@ spec.md, plan.md, and tasks.md MUST exist before any `src/` edits. Hooks enforce
 - `.specify/` — speckit configuration
 - `.claude/` — Claude Code hooks, skills, agents
 
-## Hooks Enforcement
+## Hooks Enforcement (4 Gates)
 
 This repo has PreToolUse hooks that:
-- **Block** edits to `src/` when no spec exists in `specs/`
-- **Block** commits that include .env files
-- **Allow** edits to docs, specs, config, and scripts always
+- **Gate 1**: Block edits to `src/` unless `specs/*/spec.md` exists
+- **Gate 2**: Block edits to `src/` unless `specs/*/plan.md` exists
+- **Gate 3**: Block edits to `src/` unless `specs/*/tasks.md` exists
+- **Gate 4**: Block edits to `src/` unless tasks.md has at least one `[X]` mark (forces `/speckit.implement`)
+- **Always block** commits that include .env files
+- **Always allow** edits to docs, specs, config, scripts, and tests
 
-If a hook blocks you, complete the speckit workflow first (specify → plan → tasks). That's the point.
+If a hook blocks you, complete the full speckit workflow: specify → plan → tasks → implement.
 
 ## Available Commands
 
-### Speckit Workflow
-- `/speckit.constitution` — View/update project principles
-- `/speckit.specify` — Create a feature spec
-- `/speckit.plan` — Create implementation plan
-- `/speckit.tasks` — Generate task breakdown
-- `/speckit.implement` — Execute tasks
-- `/speckit.analyze` — Cross-artifact consistency check
-- `/speckit.audit` — PRD compliance audit (custom)
-- `/speckit.coverage` — Check test coverage gate (custom)
+### Speckit Workflow (run in this order)
+1. `/speckit.specify` — Create a feature spec
+2. `/speckit.plan` — Create implementation plan
+3. `/speckit.tasks` — Generate task breakdown
+4. `/speckit.implement` — Execute tasks + PRD audit
+5. `/speckit.audit` — PRD compliance audit (also runs inside implement)
 
-### Ruflo/Claude-Flow
-- `/claude-flow-swarm` — Multi-agent swarm coordination
-- `/claude-flow-memory` — Persistent memory across sessions
+### Other
+- `/speckit.constitution` — View/update project principles
+- `/speckit.analyze` — Cross-artifact consistency check
+- `/speckit.coverage` — Check test coverage gate
 
 ## Security
 


### PR DESCRIPTION
## Summary

Two improvements discovered through 8 iterations of building against this template:

### 4-Gate Hook Enforcement
`require-spec.sh` now has 4 gates (was 3):
1. `spec.md` exists
2. `plan.md` exists
3. `tasks.md` exists
4. **NEW**: tasks.md has `[X]` marks — forces `/speckit.implement`

### PRD Audit with Fix-or-Block Flow
`speckit-audit` now runs as the final step of `/speckit.implement`:
- Attempts to **fix** gaps (missing FR comments, tests, implementations)
- Documents **unfixable** gaps in `specs/<feature>/blockers.md` with reason, impact, and resolution path
- **Stops and asks user** to confirm blockers before proceeding
- No requirement is silently skipped

### CLAUDE.md
- Fixed duplicate step numbers
- 9 clear steps: constitution → specify → plan → tasks → commit → implement → audit → test → verify
- Documents all 4 hook gates

## Evidence
Based on 8 PR iterations in yoshisada/kit:
- PRs #1-5 never ran `/speckit.implement` — wrote code directly
- PRs #6-7 had 3 gates but no implement enforcement
- PR #8 added 4th gate — confirmed it works
- No PR ran PRD audit automatically until this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)