### PR TITLE
feat: upgrade speckit-run to agent teams workflow

### DIFF
--- a/.claude/skills/speckit-run/SKILL.md
+++ b/.claude/skills/speckit-run/SKILL.md
@@ -1,15 +1,13 @@
 ---
 name: speckit-run
-description: Run the complete speckit pipeline (specify → plan → research → tasks → commit → implement with per-phase audit → smoke test → PR) using subagents to prevent context compaction. Use this instead of running each speckit command manually.
+description: Run the complete speckit pipeline using an agent team. Reads the PRD to determine team structure, then orchestrates specify → plan → tasks → implement → audit → PR.
 compatibility: Requires spec-kit project structure with .specify/ directory
 metadata:
   author: github-spec-kit
   source: custom
 ---
 
-# Speckit Run — Full Pipeline Orchestrator
-
-Run the complete speckit workflow as a series of subagents, each with a fresh context window. This prevents context compaction from losing critical instructions mid-workflow.
+# Speckit Run — Full Pipeline via Agent Team
 
 ## User Input
 
@@ -19,327 +17,236 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty). The user input is the feature description.
 
-## Why Subagents?
+## Time Tracking
 
-Each speckit command expands into a large prompt. Running them sequentially in one context causes auto-compaction — earlier instructions (including "don't stop") get compressed away. By running each step in its own agent, every step gets a full, fresh context.
+**IMPORTANT**: Track wall-clock time for the pipeline and each teammate. This provides a rough proxy for resource usage when token counts are unavailable.
 
-## Token Tracking
+1. Record the pipeline start time (ISO 8601) before spawning any teammates.
+2. When creating each task via `TaskCreate`, include `metadata: { "startedAt": "" }`.
+3. Instruct each teammate to record their start time in task metadata via `TaskUpdate` with `metadata: { "startedAt": "<ISO timestamp>" }` when they begin work.
+4. When a teammate completes their task, they should set `metadata: { "completedAt": "<ISO timestamp>" }`.
+5. The retrospective and final report use these timestamps to calculate per-role and total durations.
 
-**IMPORTANT**: Track token usage from every subagent. Each Agent tool result includes `total_tokens` in its usage metadata. After each agent completes, record:
-- Step name
-- Token count
+## Pre-Flight
 
-Keep a running total. Include the breakdown in the PR body and final report.
+1. If no user input was provided, ask the user for a feature description.
+2. Read `docs/PRD.md` — extract the feature scope, functional requirements, deliverables, and any named external dependencies.
+3. Read `.specify/memory/constitution.md` — note any constraints that affect team structure.
+4. Create a fresh git branch from main.
+5. Record the pipeline start time: `pipeline_start = <current ISO 8601 timestamp>`.
 
-## Pipeline
+## Step 1: Analyze the PRD and Design the Team
 
-Execute the following steps **sequentially**. Each step MUST complete before the next begins. Use the **Agent tool** with `subagent_type: "general-purpose"` for each step unless a specific subagent_type is noted. Do NOT run speckit commands directly in the main context.
+### Required Roles (in order)
 
-### Step 1: Specify
+The pipeline always flows through these roles. This is the minimum — you MUST have at least one teammate per role:
 
-Launch an agent with this prompt:
+1. **Specifier** — Runs `/speckit.specify`, `/speckit.plan`, `/speckit.tasks`. Produces all spec artifacts and commits them. Always runs first.
+2. **Researcher** — Resolves external dependencies referenced in the PRD. Clones starters to `vendor/`, documents findings in `research.md`. Runs after specifier if the PRD names external projects; skip this role if there are no external deps.
+3. **Implementer** — Runs `/speckit.implement`. Executes the task plan phase-by-phase, writes code matching contracts, marks tasks `[X]`, commits per phase. Runs after specifier (and researcher if present).
+4. **Auditor** — Runs after all implementers finish. Each auditor gets a **fresh context** (no implementation history polluting their judgment). Split auditors by concern so they can run in parallel:
+   - **audit-compliance**: Runs `/speckit.audit` — PRD→Spec→Code→Test verification
+   - **audit-tests**: Verifies test quality — no stubs, real assertions, coverage gate
+   - **audit-smoke**: Builds and runs the project in a temp dir, verifies runtime behavior
+   - **audit-pr**: Creates the PR with stats from all other auditors
+
+   For simple features, one auditor can do all of these. For complex features, split them so each auditor starts with a clean context and a focused lens.
+5. **Retrospective** — Messages all teammates for feedback, creates a GitHub issue with findings. Runs last, before shutdown.
+
+### Scaling Up
+
+Based on what you read in the PRD, decide where to add parallelism:
+
+- **Multiple independent components?** (e.g., CLI + templates + module system) → Spawn multiple implementers, one per component, working on different files in parallel. They all depend on the specifier finishing but can run concurrently with each other.
+- **Large module count?** (e.g., 5 installable modules) → Spawn one implementer per module, each owning its own files.
+- **Complex external deps?** → Spawn a dedicated researcher alongside the specifier so research can start as soon as the plan is done.
+- **Multiple audit concerns?** (compliance, test quality, runtime) → Spawn multiple auditors with different focus areas running in parallel. Each auditor gets a fresh context — no implementation history — so their judgment isn't biased by what they saw being built.
+
+### Decision Checklist
+
+Ask yourself:
+1. How many independent file sets can be implemented in parallel? → That many implementers.
+2. Are there external deps to fetch? → Add a researcher.
+3. Is a single audit pass sufficient? → If not, split auditors by concern.
+4. What's the total teammate count? → Keep it under 6. More teammates = more coordination overhead. Aim for 5-6 tasks per teammate.
+
+### Example Team Structures
+
+**Simple feature** (single module, no external deps):
+```
+specifier → implementer → auditor → retrospective
+```
+3 teammates, fully serial.
+
+**Medium feature** (CLI + templates, one external dep):
+```
+specifier → researcher ─┐
+                         ├→ impl-cli ──┐→ audit-code ──┐
+                         └→ impl-tmpl ─┘→ audit-tests ─┤→ retrospective
+```
+5 teammates, 2 implementers in parallel, 2 auditors in parallel.
+
+**Complex feature** (CLI + 3 modules + external starter):
+```
+specifier → researcher ─┐
+                         ├→ impl-core ──┐→ audit-compliance ─┐
+                         ├→ impl-mod-a ─┤→ audit-tests ──────┤→ retrospective
+                         └→ impl-mod-b ─┘→ audit-smoke ──────┘
+```
+7 teammates, 3 implementers in parallel, 3 auditors in parallel.
+
+Each teammate should run the speckit commands (`/speckit.specify`, `/speckit.plan`, `/speckit.tasks`, `/speckit.implement`, `/speckit.audit`) — not reimplement their logic. Implementers running in parallel should each get a filtered view of tasks.md (only their component's tasks).
+
+## Step 2: Create the Team and Tasks
+
+1. Use `TeamCreate` with a descriptive name (e.g., `speckit-{feature}`)
+2. Use `TaskCreate` to create ALL tasks. You MUST create every task listed in the **Mandatory Tasks** section below, plus any additional tasks from your PRD analysis.
+3. Set task dependencies using `TaskCreate` or `TaskUpdate` (see dependency rules below)
+4. Assign tasks to teammates by setting `owner` via `TaskUpdate`
+
+### Mandatory Tasks (NON-NEGOTIABLE — always create these)
+
+Every pipeline run MUST include these tasks regardless of feature complexity. Do NOT skip any of them:
+
+| # | Task | Owner | Depends On | Why Mandatory |
+|---|------|-------|------------|---------------|
+| 1 | Specify + plan + research + tasks | specifier | — | Produces all spec artifacts |
+| N | Implementation (1+ tasks) | implementer(s) | specifier | Builds the feature |
+| A | Audit + smoke test + create PR | auditor | all implementers | Quality gate + deliverable |
+| R | **Retrospective** | **retrospective** | **auditor** | **Self-improvement — feeds back into the skill and template. ALWAYS the second-to-last task. MUST run BEFORE shutdown.** |
+
+The retrospective task exists to make every pipeline run improve the next one. Skipping it means repeating the same friction forever.
+
+### Additional Tasks (PRD-dependent)
+
+Based on your PRD analysis, you may add:
+- Multiple implementation tasks (one per independent component) for parallelism
+- A separate researcher task if external deps need resolving
+- Multiple audit tasks split by concern (compliance, tests, smoke) for parallelism
+
+### Task Dependencies
+
+Wire dependencies following these rules:
+- All implementation tasks depend on the specifier task
+- Researcher task (if present) depends on the specifier task
+- Implementer tasks depend on the researcher task (if present)
+- Audit tasks depend on ALL implementation tasks
+- **Retrospective depends on audit** (it runs after the PR is created but BEFORE shutdown)
+
+### Task Dependency Example
 
 ```
-Read docs/PRD.md and .specify/memory/constitution.md for context.
-Run /speckit.specify with this feature description: {user input}
-Do not ask questions — the PRD has everything needed.
-When done, report the spec file path and branch name.
+Task 1: Specify (no deps)                → owner: specifier
+Task 2: Research (depends: 1)            → owner: researcher
+Task 3: Impl CLI (depends: 2)            → owner: impl-cli
+Task 4: Impl templates (depends: 2)      → owner: impl-templates
+Task 5: Audit + smoke + PR (depends: 3, 4) → owner: auditor
+Task 6: Retrospective (depends: 5)       → owner: retrospective  ← ALWAYS LAST
 ```
 
-Wait for completion. Extract the feature branch name and spec path from the result.
-
-### Step 2: Plan
-
-Launch an agent with this prompt:
-
-```
-Read .specify/memory/constitution.md and specs/{feature}/spec.md for context.
-Run /speckit.plan for feature: {feature branch name}
-Do not ask questions. Generate research.md, data-model.md, contracts/interfaces.md, quickstart.md.
-When done, report all generated artifact paths.
-```
-
-Wait for completion.
-
-### Step 3: Resolve External Dependencies (MAY ASK QUESTIONS)
-
-**This is the ONLY step in the pipeline that may come back with questions for the user.**
-
-Launch an agent with this prompt:
-
-```
-You are a research agent resolving external dependencies for feature {feature branch name}.
-
-Read these files for context:
-- docs/PRD.md — the product requirements (look for named projects, frameworks, starters, libraries)
-- specs/{feature}/research.md — technology decisions made during planning
-- specs/{feature}/plan.md — the implementation plan
-- specs/{feature}/spec.md — the feature specification
-
-Your job is to find and fetch every external project, starter, template, or library that the PRD and plan reference BY NAME. These are real projects that exist on GitHub or npm — not things to build from scratch.
-
-For each named external dependency:
-
-1. SEARCH GitHub and the web to find the actual repository or package
-2. If it's a starter/template repo (e.g., "Tamagui Takeout", "takeout-free", "create-t3-app"):
-   - Clone or download it into vendor/{name}/ in the project root
-   - Document its file structure in specs/{feature}/research.md under a new "## External Dependencies" section
-   - Note which parts should be used as the base template vs adapted vs ignored
-3. If it's a library/package:
-   - Verify the correct package name and latest stable version
-   - Document it in research.md
-4. If you CANNOT find or access a dependency:
-   - Report it as a QUESTION to the user: "The PRD references {name} but I cannot find/access it. Please provide: (a) a URL/path, (b) confirm it should be recreated from scratch, or (c) suggest an alternative."
-
-Update these files with your findings:
-- specs/{feature}/research.md — add "## External Dependencies" section with URLs, paths, and integration notes
-- specs/{feature}/plan.md — update template/file references to point to actual vendor/ paths where applicable
-
-Report:
-- Dependencies resolved: [list with URLs]
-- Dependencies cloned to vendor/: [list with paths]
-- Questions for user: [list — ONLY if something cannot be found or accessed]
-```
-
-Wait for completion.
-
-**If the agent returns questions**: Present them to the user and wait for answers. Then send the answers back to the agent (via SendMessage) so it can finish resolving.
-
-**If no questions**: Proceed to Step 4.
-
-### Step 4: Tasks
-
-Launch an agent with this prompt:
-
-```
-Read specs/{feature}/spec.md, specs/{feature}/plan.md, specs/{feature}/research.md, and specs/{feature}/contracts/interfaces.md.
-Run /speckit.tasks for feature: {feature branch name}
-Do not ask questions. Generate the complete task breakdown.
-When done, report the tasks.md path and total task count.
-```
-
-Wait for completion. **Parse the tasks.md to extract the list of phases** (Phase 1, Phase 2, etc.) — you will need this for Step 6.
-
-### Step 5: Commit Artifacts
-
-Do this step directly (not in a subagent). Commit all spec artifacts and any vendor/ dependencies:
-
-```bash
-git add specs/{feature}/ vendor/ CLAUDE.md
-git commit -m "Add spec artifacts for {feature}"
-```
-
-(If vendor/ doesn't exist or is empty, that's fine — git add will skip it.)
-
-### Step 6: Implement (Phase-by-Phase with Audit Gates)
-
-**CRITICAL**: Do NOT launch a single agent for all phases. Instead, launch a **separate implement agent per phase** followed by an **audit agent** after each phase. This catches gaps early before they compound.
-
-**Read `specs/{feature}/tasks.md` directly** to extract the phase list (e.g., "Phase 1: Setup", "Phase 2: Foundational", "Phase 3: User Story 1", etc.).
-
-For **each phase** in order:
-
-#### Step 6a: Implement Phase N
-
-Launch an agent with this prompt:
-
-```
-You are implementing Phase {N} of feature {feature branch name}.
-
-CRITICAL INSTRUCTIONS:
-- Read specs/{feature}/tasks.md — find all tasks in Phase {N}
-- Read specs/{feature}/contracts/interfaces.md — all functions must match these signatures
-- Read specs/{feature}/plan.md — this is your technical architecture
-- Read specs/{feature}/research.md — check for external dependencies in vendor/ that should be used instead of writing from scratch
-- Read specs/{feature}/spec.md — this is your requirements source
-- Read .specify/memory/constitution.md — these are governing principles
-
-If vendor/ contains external starter templates or libraries referenced in plan.md, USE THEM as the base — do not recreate from scratch.
-
-Implement ONLY the tasks in Phase {N}: {phase title}.
-For each task:
-1. Write the code matching the contract signatures exactly
-2. Every function must reference its spec FR in a comment
-3. Mark the task [X] in tasks.md immediately after completing it
-4. Write tests for the code you implemented
-
-Do NOT implement tasks from other phases.
-Do NOT stop until every task in Phase {N} is marked [X].
-If you hit an error, fix it and continue.
-When done, run the tests for this phase and report results.
-Commit your changes with message: "Implement Phase {N}: {phase title}"
-```
-
-Wait for completion.
-
-#### Step 6b: Audit Phase N
-
-After each phase completes, launch an **audit agent** (use `subagent_type: "prd-auditor"`) with this prompt:
-
-```
-You are auditing Phase {N} of feature {feature branch name}.
-
-Read docs/PRD.md for the source requirements.
-Read specs/{feature}/spec.md for the FRs.
-Read specs/{feature}/contracts/interfaces.md for the function signatures.
-Read specs/{feature}/tasks.md — check that all Phase {N} tasks are marked [X].
-
-For every FR that Phase {N} tasks claimed to implement:
-
-1. VERIFY the implementation exists — read the actual source file, find the function, confirm it matches the contract signature
-2. VERIFY the FR comment exists in the source code (// FR-NNN)
-3. VERIFY a test exists that references the acceptance scenario
-4. VERIFY the test actually tests the behavior (not just a stub)
-5. For template/scaffold tasks: VERIFY the generated files have real content, not just placeholders
-6. If the PRD references an external project (starter, template, library): VERIFY the implementation actually uses it rather than recreating it from scratch
-
-If ANY gap is found:
-- Try to FIX it (add missing comment, write missing test, flesh out stub)
-- If unfixable, document in specs/{feature}/blockers.md
-
-Report:
-- Phase {N} compliance: X/Y FRs verified
-- Gaps found and fixed: [list]
-- Blockers: [list]
-- Test results for this phase
-```
-
-Wait for completion. **If the audit reports blockers, log them but continue to the next phase.**
-
-#### Repeat 6a → 6b for every phase
-
-Continue until all phases are implemented and audited.
-
-### Step 7: Full Audit
-
-After all phases are done, launch a final **audit agent** (use `subagent_type: "prd-auditor"`) with this prompt:
-
-```
-You are running the FINAL PRD compliance audit for feature {feature branch name}.
-
-Read docs/PRD.md — extract EVERY functional requirement, deliverable, and user story.
-Read specs/{feature}/spec.md — extract every FR-NNN.
-Read specs/{feature}/contracts/interfaces.md — every function signature.
-Read .specify/memory/constitution.md — governing principles.
-
-Check BOTH directions:
-
-Phase A — PRD → Spec: Does every PRD requirement have at least one covering FR?
-Phase B — Spec → Code → Test: For every FR-NNN:
-  1. Search source files for // FR-NNN comment — READ the actual function, not just the filename
-  2. Verify the function signature matches contracts/interfaces.md
-  3. Search test files for acceptance scenario references
-  4. Verify tests actually test the behavior (not stubs)
-  5. For templates/scaffolds: verify files contain real, functional content — not placeholder stubs
-
-For generated project templates specifically:
-  - Does the README exist with setup instructions, structure overview, and module guide?
-  - Do template files contain real, runnable code (not just placeholder comments)?
-  - Would a generated project actually install dependencies and start?
-  - If the PRD names a specific starter/template (e.g., "Tamagui Takeout"), is the actual project used — not a from-scratch recreation?
-
-Fix gaps or document blockers in specs/{feature}/blockers.md.
-Report overall compliance percentage.
-```
-
-Wait for completion.
-
-### Step 8: Smoke Test
-
-Launch a **smoke test agent** (use `subagent_type: "smoke-tester"`) with this prompt:
-
-```
-You are smoke testing feature {feature branch name}.
-
-Read specs/{feature}/plan.md to determine the project type (CLI, web app, mobile, API).
-
-Perform a full runtime smoke test:
-
-1. Create a temp directory
-2. Build the project (bun run build or equivalent)
-3. Run the primary command or start the server
-4. Verify it actually works:
-   - CLI: run the main commands, check exit codes and output
-   - Web: start dev server, curl the URL, verify 200 response with real content
-   - Mobile: verify prebuild succeeds
-   - API: hit health and primary endpoints
-
-For CLI projects that generate other projects:
-   - Run the create command to generate a project
-   - cd into the generated project
-   - Run bun install (or equivalent)
-   - Verify it installs without errors
-   - Try to start the dev server
-   - Verify basic functionality works
-
-Report PASS/FAIL for each check with exact error output on failure.
-Clean up temp dir (keep on failure for debugging).
-```
-
-Wait for completion. **If smoke test FAILs, report the failures but do not retry.**
-
-### Step 9: Create Pull Request
-
-Do this step directly (not in a subagent).
-
-1. **Check for branch conflicts**: Before pushing, verify the remote branch doesn't already exist:
-   ```bash
-   git ls-remote --heads origin {branch name}
-   ```
-   - If the remote branch exists, append a suffix: `{branch name}-v2`, `-v3`, etc. until a free name is found
-   - Create and switch to the new branch name if needed: `git branch -m {new branch name}`
-
-2. **Push the branch**:
-   ```bash
-   git push -u origin {branch name}
-   ```
-
-3. **Create the PR** using `gh pr create`:
-   - Title: short summary of the feature (under 70 chars)
-   - Body: include Summary (bullet points), Stats (files, tests, coverage, compliance), Test Plan (checklist of what was verified), and the smoke test result
-   - Format:
-   ```
-   gh pr create --title "{title}" --body "$(cat <<'EOF'
-   ## Summary
-   - {bullet points from the pipeline report}
-
-   ## Stats
-   - **Files**: {count}
-   - **Tests**: {count} passing, {coverage}% coverage
-   - **Compliance**: {percentage} ({X}/{Y} FRs)
-   - **Smoke Test**: {PASS/FAIL}
-
-   ## Token Usage
-   | Step | Tokens |
-   |------|--------|
-   | Specify | {n} |
-   | Plan | {n} |
-   | Research | {n} |
-   | Tasks | {n} |
-   | Phase 1 Impl | {n} |
-   | Phase 1 Audit | {n} |
-   | ... | ... |
-   | Final Audit | {n} |
-   | Smoke Test | {n} |
-   | **Total** | **{sum}** |
-
-   ## Test plan
-   - [x] Unit tests passing
-   - [x] E2E tests passing
-   - [x] Coverage >= 80%
-   - [x] PRD audit: {compliance}%
-   - [x] Smoke test: {result}
-
-   🤖 Generated with [Claude Code](https://claude.com/claude-code)
-   EOF
-   )"
-   ```
-
-4. **Report the PR URL** to the user.
-
-### Step 10: Report
-
-After all steps complete, summarize in the main context:
+The system automatically unblocks dependent tasks when their dependencies complete.
+
+### Pre-Spawn Checklist
+
+Before spawning any teammates, verify:
+- [ ] Specifier task exists
+- [ ] At least one implementation task exists
+- [ ] Audit task exists
+- [ ] **Retrospective task exists** ← if this is missing, add it now
+- [ ] All dependencies are wired correctly
+- [ ] Every task has an owner assigned
+
+## Step 3: Spawn Teammates
+
+Spawn teammates using the `Agent` tool with:
+- `team_name` set to the team name from Step 2
+- `name` set to a descriptive name (e.g., `specifier`, `impl-core`, `auditor`)
+- `run_in_background: true`
+- `mode: "bypassPermissions"`
+
+Each teammate's prompt should include:
+- The working directory and branch name
+- Which tasks they own (by task ID or description)
+- Instructions to run the appropriate speckit commands for their tasks
+- The feature description from user input
+- Instructions to use `TaskUpdate` to mark tasks in-progress when starting and completed when done, including `metadata: { "startedAt": "<ISO timestamp>" }` when starting and `metadata: { "completedAt": "<ISO timestamp>" }` when done
+- Instructions to use `SendMessage` to notify dependent teammates when unblocked
+- Instructions to check `TaskList` after completing each task to find the next available work
+- Instructions to read `~/.claude/teams/{team-name}/config.json` to discover other teammates by name
+
+### Key Rules for All Teammates
+
+Include these in every teammate prompt:
+- Read `.specify/memory/constitution.md` before any code changes
+- Run the speckit slash commands — don't reimplement their logic
+- Mark tasks via `TaskUpdate` (in_progress → completed)
+- After completing a task, check `TaskList` for the next unblocked, unassigned task
+- Message the next teammate by **name** when their work is unblocked
+- No two teammates should edit the same file — each owns specific file sets
+- Every exported function MUST match `specs/<feature>/contracts/interfaces.md` exactly
+- Mark tasks `[X]` in tasks.md IMMEDIATELY after completing each one
+- Commit after each phase, not in one big batch
+- Coverage gate: >=80%
+
+### Teammate Idle Behavior
+
+Teammates go idle after every turn — this is normal. An idle teammate can still receive messages. If a teammate sends a message and then goes idle, that's the expected flow (they sent their message and are waiting for a response). Do NOT treat idle as an error or shutdown.
+
+## Step 4: Monitor and Steer
+
+After spawning, you are the **team lead**. Your job is coordination, not implementation.
+
+1. **Messages arrive automatically** — no need to poll. When teammates send messages, they appear as new conversation turns.
+2. **Do NOT implement tasks yourself** — wait for teammates to complete their work.
+3. If a teammate reports a blocked task that should be unblocked, nudge the blocking teammate or update the task status.
+4. If a teammate is stuck on an error, investigate and provide guidance via `SendMessage`.
+5. If a teammate stops early (tasks remain incomplete), spawn a replacement to continue.
+6. Track progress via `TaskList` — check periodically to see what's done and what's blocked.
+
+### Handling Teammate Communication
+
+- Use `SendMessage` with the teammate's **name** (not agentId) to communicate.
+- Peer DM visibility: when teammates message each other, a brief summary appears in their idle notification. This is informational — you don't need to respond.
+- Use broadcast sparingly — token costs scale with team size.
+
+## Step 5: Retrospective (NON-NEGOTIABLE — do NOT skip)
+
+**STOP. Before sending ANY shutdown requests, the retrospective MUST run.**
+
+The retrospective teammate was already spawned in Step 3 with the other teammates. It has been waiting (blocked on the audit task). Once the auditor completes and the retrospective task unblocks, the retrospective teammate should begin automatically. If it doesn't, nudge it via `SendMessage`.
+
+The retrospective teammate's job:
+1. Messages every still-running teammate asking: "What friction did you hit? What would you change about the workflow, the speckit commands, or the team structure?"
+2. Collects their responses
+3. Reviews the pipeline artifacts for additional evidence:
+   - `specs/{feature}/blockers.md` — documented blockers
+   - `git log` — commit flow and any fixup commits that indicate rework
+   - Test results — any failures, flaky tests, environment issues
+   - Task list — tasks that were stuck, reassigned, or took unusually long
+4. Collects timing data from task metadata (`startedAt`, `completedAt`) via `TaskGet` for each task, calculates per-role durations and total pipeline wall-clock time.
+5. Creates a GitHub issue on the **ai-repo-template** repo with `gh issue create -R yoshisada/ai-repo-template` containing:
+   - **What worked well** (with evidence)
+   - **What didn't work well** (with evidence)
+   - **Proposed changes** — concrete suggestions for the skill, speckit commands, team structure, or codebase
+   - **Timing breakdown** — per-role wall-clock durations and total pipeline time
+6. If any proposed changes are **high-confidence fixes** (clear bugs, documented friction that hit multiple agents, or violations of the constitution), create a PR with exact diffs:
+   - Clone the ai-repo-template repo (if not already present) and create a branch: `retro/{feature}-{date}`
+   - Apply ONLY changes that are **absolutely required** — fixes for problems that caused real friction or failures during this run. Do NOT include speculative improvements or nice-to-haves.
+   - Each changed file must have a clear justification tied to evidence from the retro (teammate feedback, blockers, fixup commits)
+   - Open a PR with `gh pr create -R yoshisada/ai-repo-template` linking back to the retro issue
+   - If no changes meet the high-confidence bar, skip the PR and note "No high-confidence fixes identified" in the issue
+7. Reports the issue URL (and PR URL if created) back to the lead
+8. Marks its task as completed via `TaskUpdate`
+
+**Only proceed to Step 6 after the retrospective task is marked completed.**
+
+## Step 6: Report and Cleanup
+
+1. **Verify retrospective ran**: Check `TaskList` — the retrospective task MUST be completed. If not, go back to Step 5.
+2. **Shut down teammates gracefully**: Send each teammate `SendMessage` with `message: {type: "shutdown_request"}`. They can approve or reject — if rejected, check why before retrying.
+3. **Wait for all teammates to shut down** before cleaning up.
+4. **Clean up**: Use `TeamDelete` to remove the team and task directories.
+5. **Summarize** the pipeline results:
 
 ```
 ## Pipeline Report: {feature branch name}
@@ -348,17 +255,13 @@ After all steps complete, summarize in the main context:
 |------|--------|---------|
 | Specify | [Done/Failed] | {FR count, user story count} |
 | Plan | [Done/Failed] | {artifact count} |
-| Research | [Done/Skipped/Questions] | {deps resolved, questions asked} |
+| Research | [Done/Skipped/Questions] | {deps resolved} |
 | Tasks | [Done/Failed] | {phase count, task count} |
 | Commit | [Done/Failed] | {commit hash} |
-| Phase 1 Impl | [Done/Failed] | {tasks completed} |
-| Phase 1 Audit | [Pass/Fail] | {compliance %} |
-| ... | ... | ... |
-| Phase N Impl | [Done/Failed] | {tasks completed} |
-| Phase N Audit | [Pass/Fail] | {compliance %} |
-| Final Audit | [Pass/Fail] | {overall compliance %} |
-| Smoke Test | [Pass/Fail] | {checks passed/failed} |
+| Implementation | [Done/Failed] | {phases completed, tasks done} |
+| Audit | [Pass/Fail] | {compliance %, test quality, smoke result} |
 | PR | [Created/Failed] | {PR URL} |
+| Retrospective | [Done/Failed] | {issue URL}, {PR URL or "no fixes needed"} |
 
 **Branch**: {branch name}
 **PR**: {URL}
@@ -366,21 +269,25 @@ After all steps complete, summarize in the main context:
 **Compliance**: {percentage}
 **Blockers**: {count} — see specs/{feature}/blockers.md
 **Smoke Test**: {PASS/FAIL}
-**Total Tokens**: {sum across all agents}
+**Retrospective**: {issue URL}
+**Wall-Clock Time**: {total pipeline duration}
+
+### Timing Breakdown
+
+| Role | Duration |
+|------|----------|
+| Specifier | {duration} |
+| Researcher | {duration or N/A} |
+| Implementer(s) | {duration — longest if parallel} |
+| Auditor | {duration} |
+| Retrospective | {duration} |
+| **Total Pipeline** | **{start to finish}** |
 ```
 
 ## Error Handling
 
-- If any agent fails, report the error and the step that failed
+- If a teammate fails, check its last message and task status
+- If `/speckit.implement` stops early, spawn a replacement to continue from where it left off
+- Unfixable gaps go in `specs/{feature}/blockers.md` — pipeline continues
 - Do NOT retry automatically — report to the user and ask how to proceed
-- If an implement agent stops early (tasks remain unchecked in that phase), launch a new implement agent for the remaining tasks in that phase
-
-## Notes
-
-- Each agent gets a fresh context window — no compaction risk
-- The main context stays lean — just orchestration and results
-- Step 3 (Research) is the ONLY step that may ask the user questions — all other steps run autonomously
-- Per-phase audits catch gaps early before they compound across phases
-- The smoke test validates runtime behavior — not just test results
-- The PR step safely handles existing branches by appending version suffixes
-- Feature description comes from $ARGUMENTS or the user's message
+- If TeamDelete fails because teammates are still active, shut them down first


### PR DESCRIPTION
## Summary
- Replaces sequential subagent pipeline with agent team workflow
- Team roles: specifier → researcher → implementer(s) (parallel) → auditor → retrospective
- Wall-clock time tracking via task metadata timestamps per role
- Retrospective creates issue (full retro log) + PR with exact diffs for high-confidence fixes only

## First run results (yoshisada/kit#17)
- 100% PRD compliance (15/15 FRs), 91.54% test coverage, 63 tests, smoke PASS
- Retrospective: #6

## Test plan
- [ ] Verify skill loads and parses PRD to design team
- [ ] Verify pipeline completes end-to-end with correct role ordering
- [ ] Verify time tracking appears in final report

🤖 Generated with [Claude Code](https://claude.com/claude-code)